### PR TITLE
Bring patches from v0.315.0-dd-patch into a v0.316.0 branch

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1422,7 +1422,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		v = sql.NullFloat64{}
 	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
 		v = sql.NullTime{}
-	case "map":
+	case "map", "hstore":
 		v = NullMap{}
 	case "array":
 		if len(typeNames) <= 1 {
@@ -1519,7 +1519,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Time, err
-	case "map":
+	case "map", "hstore":
 		if err := validateMap(v); err != nil {
 			return nil, err
 		}

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1410,7 +1410,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 	switch typeNames[0] {
 	case "boolean":
 		v = sql.NullBool{}
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "pg_json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
 		v = sql.NullString{}
 	case "tinyint", "smallint":
 		v = sql.NullInt32{}
@@ -1495,7 +1495,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
+	case "json", "pg_json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1422,7 +1422,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		v = sql.NullFloat64{}
 	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
 		v = sql.NullTime{}
-	case "map", "hstore":
+	case "map", "hstore", "hstore_csv":
 		v = NullMap{}
 	case "array":
 		if len(typeNames) <= 1 {
@@ -1519,7 +1519,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Time, err
-	case "map", "hstore":
+	case "map", "hstore", "hstore_csv":
 		if err := validateMap(v); err != nil {
 			return nil, err
 		}

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1410,7 +1410,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 	switch typeNames[0] {
 	case "boolean":
 		v = sql.NullBool{}
-	case "json", "pg_json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "pgjson", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
 		v = sql.NullString{}
 	case "tinyint", "smallint":
 		v = sql.NullInt32{}
@@ -1495,7 +1495,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "pg_json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
+	case "json", "pgjson", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err


### PR DESCRIPTION
We maintain a `v0.315.0-dd-patch` branch that contains small DD-specific patches on top of v0.315.0. Now we wish to bump to the v0.316.0 version, which fixes [this issue](https://github.com/trinodb/trino-go-client/issues/116).

For that we are merging all patches into a new `v0.316.0-dd-patch` branch.

Checks
-------

- The PR's changes match the patches in v0.315.0-dd-patch: https://github.com/DataDog/trino-go-client/compare/v0.315.0...v0.315.0-dd-patch
- The bump to v0.316.0 doesn't contain any breaking or risky changes: https://github.com/DataDog/trino-go-client/compare/v0.315.0...v0.316.0