### PR TITLE
Support alternative polling API

### DIFF
--- a/trino/polling.go
+++ b/trino/polling.go
@@ -1,0 +1,439 @@
+package trino
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+
+	_ "unsafe" // for go:linkname
+)
+
+// PollingConn provides a polling-based interface to Trino queries.
+// Unlike the standard sql.DB interface which blocks until the query completes,
+// this allows starting a query and polling for results incrementally.
+type PollingConn struct {
+	conn *Conn
+}
+
+// PollingResult contains the results of a query start or poll operation.
+type PollingResult struct {
+	QueryID string
+	// Indicated whether the query has completed
+	Finished bool
+	// The URI to poll for more results (empty when Finished is true)
+	NextURI string
+
+	// Partial results of DQL statements (SELECT, EXPLAIN, EXECUTE) returned in
+	// this poll, if any.
+	Rows *PollingRows
+
+	// Partial results of DML statements (INSERT, UPDATE, DELETE) returned in
+	// this poll, if any.
+	UpdateType  string
+	UpdateCount int64
+}
+
+// PollingColumnType provides type information for a column. It is a copy of database/sql.ColumnType,
+// used to parse column types similarly as done in the sync client. We cannot instantiate database/sql.ColumnType
+// directly as it has private fields.
+type PollingColumnType struct {
+	name string
+
+	hasNullable       bool
+	hasLength         bool
+	hasPrecisionScale bool
+
+	nullable     bool
+	length       int64
+	databaseType string
+	precision    int64
+	scale        int64
+	scanType     reflect.Type
+}
+
+func (t *PollingColumnType) Name() string {
+	return t.name
+}
+
+func (t *PollingColumnType) DatabaseTypeName() string {
+	return t.databaseType
+}
+
+func (t *PollingColumnType) DecimalSize() (precision, scale int64, ok bool) {
+	return t.precision, t.scale, t.hasPrecisionScale
+}
+
+// NewPollingConn creates a new polling connection from a DSN and HTTP client.
+func NewPollingConn(dsn string, httpClient *http.Client) (*PollingConn, error) {
+	// Register the custom HTTP client if provided
+	if httpClient != nil {
+		clientKey := "polling_client"
+		err := RegisterCustomClient(clientKey, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("could not register HTTP client: %w", err)
+		}
+		// Append custom_client parameter to DSN
+		if strings.Contains(dsn, "?") {
+			dsn = dsn + "&custom_client=" + clientKey
+		} else {
+			dsn = dsn + "?custom_client=" + clientKey
+		}
+	}
+
+	conn, err := newConn(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &PollingConn{conn: conn}, nil
+}
+
+// StartQuery starts executing a query and returns any initial results along
+// with a NextURI for polling.
+func (pc *PollingConn) StartQuery(ctx context.Context, query string, args ...any) (*PollingResult, error) {
+	st := &driverStmt{conn: pc.conn, query: query}
+
+	// Convert args to driver.NamedValue format
+	driverArgs := convertQueryArgsToDriverArgs(args...)
+
+	// Execute the query start logic (POST /v1/statement)
+	qresp, err := pc.startQuery(ctx, st, query, driverArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return pc.buildPollingResult(qresp)
+}
+
+// PollQuery polls for more query results using the NextURI from a previous
+// result.
+func (pc *PollingConn) PollQuery(ctx context.Context, nextURI string) (*PollingResult, error) {
+	st := &driverStmt{conn: pc.conn, query: ""}
+
+	qresp, err := pc.pollQuery(ctx, st, nextURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return pc.buildPollingResult(qresp)
+}
+
+// convertQueryArgsToDriverArgs converts query args (including `X-Trino-*` named args)
+// to the format expected by the trino driver.
+//
+// This is useful for users who want to use the polling API with the same arguments
+// they would use with sql.DB, such as sql.Named for headers like X-Trino-User.
+//
+// Loosely based on the logic in database/sql.driverArgsConnLocked.
+func convertQueryArgsToDriverArgs(queryArgs ...any) []driver.NamedValue {
+	named := make([]driver.NamedValue, len(queryArgs))
+
+	for i, arg := range queryArgs {
+		ord := i + 1
+		switch v := arg.(type) {
+		case driver.NamedValue:
+			nv := v
+			nv.Ordinal = ord
+			named[i] = nv
+		case *driver.NamedValue:
+			if v == nil {
+				named[i] = driver.NamedValue{Ordinal: ord, Value: nil}
+			} else {
+				nv := *v
+				nv.Ordinal = ord
+				named[i] = nv
+			}
+		case sql.NamedArg:
+			named[i] = driver.NamedValue{Ordinal: ord, Name: v.Name, Value: v.Value}
+		case *sql.NamedArg:
+			if v == nil {
+				named[i] = driver.NamedValue{Ordinal: ord, Value: nil}
+			} else {
+				named[i] = driver.NamedValue{Ordinal: ord, Name: v.Name, Value: v.Value}
+			}
+		default:
+			// Plain positional parameter
+			named[i] = driver.NamedValue{Ordinal: ord, Value: arg}
+		}
+	}
+	return named
+}
+
+// startQuery implements the logic from driverStmt.exec to start a query.
+func (pc *PollingConn) startQuery(ctx context.Context, st *driverStmt, query string, args []driver.NamedValue) (*queryResponse, error) {
+	hs := make(http.Header)
+	hs.Add("X-Trino-Client-Capabilities", "PARAMETRIC_DATETIME")
+
+	if len(args) > 0 {
+		var ss []string
+		for _, arg := range args {
+			if arg.Name == trinoProgressCallbackParam {
+				st.conn.progressUpdater = arg.Value.(ProgressUpdater)
+				continue
+			}
+			if arg.Name == trinoProgressCallbackPeriodParam {
+				st.conn.progressUpdaterPeriod.Period = arg.Value.(time.Duration)
+				continue
+			}
+
+			s, err := Serial(arg.Value)
+			if err != nil {
+				return nil, err
+			}
+
+			if strings.HasPrefix(arg.Name, trinoHeaderPrefix) {
+				headerValue := arg.Value.(string)
+				if arg.Name == trinoUserHeader {
+					st.user = headerValue
+				}
+				hs.Add(arg.Name, headerValue)
+			} else {
+				if hs.Get(preparedStatementHeader) == "" {
+					for _, v := range st.conn.httpHeaders.Values(preparedStatementHeader) {
+						hs.Add(preparedStatementHeader, v)
+					}
+					hs.Add(preparedStatementHeader, preparedStatementName+"="+url.QueryEscape(st.query))
+				}
+				ss = append(ss, s)
+			}
+		}
+		if (st.conn.progressUpdater != nil && st.conn.progressUpdaterPeriod.Period == 0) || (st.conn.progressUpdater == nil && st.conn.progressUpdaterPeriod.Period > 0) {
+			return nil, ErrInvalidProgressCallbackHeader
+		}
+		if len(ss) > 0 {
+			query = "EXECUTE " + preparedStatementName + " USING " + strings.Join(ss, ", ")
+		}
+	}
+
+	var cancel context.CancelFunc = func() {}
+	if _, ok := ctx.Deadline(); !ok {
+		ctx, cancel = context.WithTimeout(ctx, DefaultQueryTimeout)
+	}
+	defer cancel()
+
+	req, err := st.conn.newRequest(ctx, "POST", st.conn.baseURL+"/v1/statement", strings.NewReader(query), hs)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := st.conn.roundTrip(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var qresp queryResponse
+	d := json.NewDecoder(resp.Body)
+	d.UseNumber()
+	err = d.Decode(&qresp)
+	if err != nil {
+		return nil, fmt.Errorf("trino: %w", err)
+	}
+
+	return &qresp, handleResponseError(resp.StatusCode, qresp.Error)
+}
+
+// pollQuery implements the polling logic to get more results.
+func (pc *PollingConn) pollQuery(ctx context.Context, st *driverStmt, nextURI string) (*queryResponse, error) {
+	hs := make(http.Header)
+	hs.Add(trinoUserHeader, "trino-polling-client")
+
+	req, err := st.conn.newRequest(ctx, "GET", nextURI, nil, hs)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, context.Canceled
+		}
+		return nil, err
+	}
+
+	resp, err := st.conn.roundTrip(ctx, req)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, context.Canceled
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var qresp queryResponse
+	d := json.NewDecoder(resp.Body)
+	d.UseNumber()
+	err = d.Decode(&qresp)
+	if err != nil {
+		return nil, fmt.Errorf("trino: %w", err)
+	}
+
+	return &qresp, handleResponseError(resp.StatusCode, qresp.Error)
+}
+
+// buildPollingResult converts internal queryResponse to public PollingResult.
+func (pc *PollingConn) buildPollingResult(qresp *queryResponse) (*PollingResult, error) {
+	result := &PollingResult{
+		QueryID:     qresp.ID,
+		Finished:    qresp.NextURI == "",
+		NextURI:     qresp.NextURI,
+		UpdateType:  qresp.UpdateType,
+		UpdateCount: qresp.UpdateCount,
+	}
+
+	// Parse columns if available
+	if len(qresp.Columns) > 0 {
+		// Initialize driverRows to handle type parsing
+		rows := &driverRows{}
+		err := rows.initColumns(qresp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse columns: %w", err)
+		}
+		rows.data = qresp.Data
+		rows.rowindex = 0
+
+		columns := rows.columns
+
+		// Extract column types
+		columnTypes := rowsColumnInfoSetupConnLocked(rows)
+
+		// Convert data rows
+		data := make([][]interface{}, len(qresp.Data))
+		for i := range qresp.Data {
+			dest := make([]driver.Value, len(rows.coltype))
+			rows.rowindex = i
+			err := rows.Next(dest)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse row %d: %w", i, err)
+			}
+
+			// Convert driver.Value to interface{}
+			data[i] = make([]interface{}, len(dest))
+			for j, val := range dest {
+				data[i][j] = val
+			}
+		}
+
+		// Create PollingRows with the parsed data
+		result.Rows = newPollingRows(columns, columnTypes, data)
+	}
+
+	return result, nil
+}
+
+// PollingRows wraps query result data to provide a sql.Rows-like interface for easier
+// iteration and scanning of query results.
+type PollingRows struct {
+	columns      []string
+	columnTypes  []*PollingColumnType
+	data         [][]interface{}
+	nextRowIndex int
+	lastErr      error
+}
+
+// newPollingRows creates a PollingRows from columns, column types, and data.
+// This is an internal constructor used by buildPollingResult.
+func newPollingRows(columns []string, columnTypes []*PollingColumnType, data [][]interface{}) *PollingRows {
+	return &PollingRows{
+		columns:      columns,
+		columnTypes:  columnTypes,
+		data:         data,
+		nextRowIndex: -1,
+	}
+}
+
+// Columns returns the column names.
+func (pr *PollingRows) Columns() ([]string, error) {
+	return pr.columns, nil
+}
+
+// ColumnTypes returns the column type information.
+func (pr *PollingRows) ColumnTypes() ([]*PollingColumnType, error) {
+	return pr.columnTypes, nil
+}
+
+// Next advances to the next row. Returns false when there are no more rows.
+func (pr *PollingRows) Next() bool {
+	pr.nextRowIndex++
+	return pr.nextRowIndex < len(pr.data)
+}
+
+// Scan copies the columns in the current row into the values pointed at by dest.
+func (pr *PollingRows) Scan(dest ...any) error {
+	if pr.nextRowIndex < 0 || pr.nextRowIndex >= len(pr.data) {
+		pr.lastErr = io.EOF
+		return pr.lastErr
+	}
+
+	row := pr.data[pr.nextRowIndex]
+	if len(dest) != len(row) {
+		pr.lastErr = fmt.Errorf("trino: expected %d destination arguments in Scan, not %d", len(row), len(dest))
+		return pr.lastErr
+	}
+
+	for i, val := range row {
+		pr.lastErr = convertAssign(dest[i], val)
+		if pr.lastErr != nil {
+			pr.lastErr = fmt.Errorf(`trino: Scan error on column index %d, name %q: %w`, i, pr.columns[i], pr.lastErr)
+			return pr.lastErr
+		}
+	}
+	return nil
+}
+
+// Close closes the rows iterator. Currently a no-op.
+func (pr *PollingRows) Close() error {
+	return nil
+}
+
+// Err returns the error, if any, that was encountered during iteration.
+func (pr *PollingRows) Err() error {
+	if pr.lastErr != io.EOF {
+		return pr.lastErr
+	}
+	return nil
+}
+
+// Copy of database/sql.rowsColumnInfoSetupConnLocked, writing into PollingColumnType
+// instead of database/sql.ColumnType.
+func rowsColumnInfoSetupConnLocked(rowsi driver.Rows) []*PollingColumnType {
+	names := rowsi.Columns()
+
+	list := make([]*PollingColumnType, len(names))
+	for i := range list {
+		ci := &PollingColumnType{name: names[i]}
+		list[i] = ci
+
+		if prop, ok := rowsi.(driver.RowsColumnTypeScanType); ok {
+			ci.scanType = prop.ColumnTypeScanType(i)
+		} else {
+			ci.scanType = reflect.TypeFor[any]()
+		}
+		if prop, ok := rowsi.(driver.RowsColumnTypeDatabaseTypeName); ok {
+			ci.databaseType = prop.ColumnTypeDatabaseTypeName(i)
+		}
+		if prop, ok := rowsi.(driver.RowsColumnTypeLength); ok {
+			ci.length, ci.hasLength = prop.ColumnTypeLength(i)
+		}
+		if prop, ok := rowsi.(driver.RowsColumnTypeNullable); ok {
+			ci.nullable, ci.hasNullable = prop.ColumnTypeNullable(i)
+		}
+		if prop, ok := rowsi.(driver.RowsColumnTypePrecisionScale); ok {
+			ci.precision, ci.scale, ci.hasPrecisionScale = prop.ColumnTypePrecisionScale(i)
+		}
+	}
+	return list
+}
+
+// convertAssign is linked to database/sql.convertAssign which is used to convert
+// interface{} values from the driver to typed destinations.
+//
+// This method should be stable across versions as it is widely accessed across packages using
+// linkname, and documented as such:
+// https://cs.opensource.google/go/go/+/master:src/database/sql/convert.go;l=209-223
+//
+//go:linkname convertAssign database/sql.convertAssign
+func convertAssign(dest, src any) error

--- a/trino/polling.go
+++ b/trino/polling.go
@@ -17,6 +17,10 @@ import (
 	_ "unsafe" // for go:linkname
 )
 
+const (
+	pollingUserName = "trino-polling-user"
+)
+
 // PollingConn provides a polling-based interface to Trino queries.
 // Unlike the standard sql.DB interface which blocks until the query completes,
 // this allows starting a query and polling for results incrementally.
@@ -124,6 +128,33 @@ func (pc *PollingConn) PollQuery(ctx context.Context, nextURI string) (*PollingR
 	}
 
 	return pc.buildPollingResult(qresp)
+}
+
+// CancelQuery cancels an in-progress query by sending a DELETE request to the
+// nextURI. This is safe to call even after a query has completed.
+func (pc *PollingConn) CancelQuery(ctx context.Context, nextURI string) error {
+	hs := http.Header{trinoUserHeader: {pollingUserName}}
+
+	if nextURI == "" {
+		return errors.New("trino: cannot cancel query with empty nextURI")
+	}
+
+	req, err := pc.conn.newRequest(ctx, "DELETE", nextURI, nil, hs)
+	if err != nil {
+		return err
+	}
+
+	resp, err := pc.conn.roundTrip(ctx, req)
+	if err != nil {
+		// If the error is StatusNoContent, the query was successfully cancelled
+		qferr, ok := err.(*ErrQueryFailed)
+		if ok && qferr.StatusCode == http.StatusNoContent {
+			return nil
+		}
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // convertQueryArgsToDriverArgs converts query args (including `X-Trino-*` named args)
@@ -243,8 +274,7 @@ func (pc *PollingConn) startQuery(ctx context.Context, st *driverStmt, query str
 
 // pollQuery implements the polling logic to get more results.
 func (pc *PollingConn) pollQuery(ctx context.Context, st *driverStmt, nextURI string) (*queryResponse, error) {
-	hs := make(http.Header)
-	hs.Add(trinoUserHeader, "trino-polling-client")
+	hs := http.Header{trinoUserHeader: {pollingUserName}}
 
 	req, err := st.conn.newRequest(ctx, "GET", nextURI, nil, hs)
 	if err != nil {

--- a/trino/polling_integration_test.go
+++ b/trino/polling_integration_test.go
@@ -98,6 +98,69 @@ func TestIntegrationPollingSelectTpch1000(t *testing.T) {
 	}
 }
 
+func TestIntegrationPollingCancelQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Use triple CROSS JOIN to create a very large result set that takes time to execute
+	longQuery := "SELECT COUNT(*) FROM tpch.sf1.customer c1 CROSS JOIN tpch.sf1.customer c2 CROSS JOIN tpch.sf1.customer c3"
+
+	result, err := pollingConn.StartQuery(ctx, longQuery)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.QueryID)
+	assert.NotEmpty(t, result.NextURI)
+
+	t.Logf("Query %s started, cancelling immediately", result.QueryID)
+
+	err = pollingConn.CancelQuery(ctx, result.NextURI)
+	require.NoError(t, err)
+
+	t.Logf("Cancel request sent successfully for query %s", result.QueryID)
+
+	// Try to poll the cancelled query - it should either return with an error or show as finished
+	pollResult, pollErr := pollingConn.PollQuery(ctx, result.NextURI)
+	if pollErr != nil {
+		t.Logf("Polling after cancel returned error (expected): %v", pollErr)
+		return
+	}
+
+	assert.True(t, pollResult.Finished, "Expected query to be finished after cancellation")
+	t.Logf("Query %s successfully cancelled", result.QueryID)
+}
+
+func TestIntegrationPollingCancelQueryAfterCompletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := pollingConn.StartQuery(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	nextURI := result.NextURI
+
+	for !result.Finished {
+		result, err = pollingConn.PollQuery(ctx, result.NextURI)
+		require.NoError(t, err)
+		if result.NextURI != "" {
+			nextURI = result.NextURI
+		}
+	}
+
+	err = pollingConn.CancelQuery(ctx, nextURI)
+	assert.NoError(t, err, "Cancelling completed query should not error")
+}
+
 func TestIntegrationPollingQueryWithNoResults(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")

--- a/trino/polling_integration_test.go
+++ b/trino/polling_integration_test.go
@@ -265,6 +265,117 @@ func TestIntegrationPollingQueryWithNamedArgs(t *testing.T) {
 	assert.Equal(t, [][]interface{}{{int64(1)}}, rows)
 }
 
+// Tests comparing sync (standard SQL) vs polling client results
+
+func TestIntegrationSyncAndPollingReturnSimilarFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	query := `
+		SELECT n as col1, CAST(n as varchar) as col2
+		FROM table(sequence(1, 3)) as t(n)
+	`
+
+	t.Run("Sync", func(t *testing.T) {
+		columns, columnTypes, rows := executeSync(t, dsn, query)
+		assert.Equal(t, columns, []string{"col1", "col2"})
+		assert.Equal(t, columnTypes, []string{"BIGINT", "VARCHAR"})
+		assert.Equal(t, rows, [][]interface{}{{int64(1), "1"}, {int64(2), "2"}, {int64(3), "3"}})
+	})
+
+	t.Run("Polling", func(t *testing.T) {
+		columns, columnTypes, rows := executePolling(t, dsn, query)
+		assert.Equal(t, columns, []string{"col1", "col2"})
+		assert.Equal(t, columnTypes, []string{"BIGINT", "VARCHAR"})
+		assert.Equal(t, rows, [][]interface{}{{int64(1), "1"}, {int64(2), "2"}, {int64(3), "3"}})
+	})
+}
+
+func TestIntegrationCompareSyncAndPollingResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+
+	testCases := []struct {
+		name  string
+		query string
+		args  []interface{}
+	}{
+		{
+			name:  "ARRAY of integers and strings",
+			query: `SELECT ARRAY[1, 2, 3] AS col1, ARRAY['a', 'b', 'c'] AS col2`,
+		},
+		{
+			name:  "Query with parameters",
+			query: `SELECT ? AS col1, ? AS col2`,
+			args:  []interface{}{1, "a"},
+		},
+		{
+			name:  "EXPLAIN query",
+			query: `EXPLAIN SELECT 1`,
+		},
+		{
+			name:  "Nested ARRAY",
+			query: `SELECT ARRAY[ARRAY[ARRAY[1.4]]]`,
+		},
+		{
+			name:  "MAP with nested values",
+			query: `SELECT MAP(ARRAY['foo'], ARRAY[MAP(ARRAY['key1'], ARRAY[CAST(1 AS INTEGER)])]) as col`,
+		},
+		{
+			name:  "ROW with mixed types",
+			query: `SELECT ROW(1, 5.12, 'foo', false, NULL)`,
+		},
+		{
+			name:  "ROW with DECIMAL and NULL",
+			query: `SELECT ROW(CAST(5 AS INTEGER), CAST(1 AS DECIMAL(10, 2)), CAST(NULL AS VARCHAR))`,
+		},
+		{
+			name:  "ARRAY of REAL",
+			query: `SELECT ARRAY[CAST(2.3 AS REAL)]`,
+		},
+		{
+			name:  "ARRAY of DOUBLE",
+			query: `SELECT ARRAY[CAST(2.3 AS DOUBLE)]`,
+		},
+		{
+			name:  "ARRAY of TINYINT",
+			query: `SELECT ARRAY[CAST(2.3 AS TINYINT)]`,
+		},
+		{
+			name:  "ARRAY of INTEGER",
+			query: `SELECT ARRAY[CAST(2.3 AS INTEGER)]`,
+		},
+		{
+			name:  "ARRAY of BIGINT",
+			query: `SELECT ARRAY[CAST(2.3 AS BIGINT)]`,
+		},
+		{
+			name:  "ARRAY of SMALLINT",
+			query: `SELECT ARRAY[CAST(2.3 AS SMALLINT)]`,
+		},
+		{
+			name:  "SELECT from sequence with filter",
+			query: `SELECT n FROM table(sequence(1, 100)) as t(n) WHERE n <= 5`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			syncCols, syncColTypes, syncRows := executeSync(t, dsn, tc.query, tc.args...)
+			pollingCols, pollingColTypes, pollingRows := executePolling(t, dsn, tc.query, tc.args...)
+
+			assert.Equal(t, syncCols, pollingCols, "Column names should match")
+			assert.Equal(t, syncColTypes, pollingColTypes, "Column types should match")
+			assert.Equal(t, syncRows, pollingRows, "Rows should match")
+		})
+	}
+}
+
 // collectAllResults is a helper that polls until the query finishes and collects all results.
 func collectAllResults(ctx context.Context, pc *PollingConn, result *PollingResult) ([][]interface{}, []string, []*PollingColumnType, error) {
 	var err error
@@ -314,4 +425,74 @@ func scanAllRows(pr *PollingRows) ([][]interface{}, error) {
 	}
 
 	return rows, pr.Err()
+}
+
+// Execute a sync query using standard SQL interface and return its results
+func executeSync(
+	t *testing.T,
+	dsn string,
+	query string,
+	args ...interface{},
+) (columns []string, columnTypes []string, rows [][]interface{}) {
+	db, err := sql.Open("trino", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	sqlRows, err := db.Query(query, args...)
+	require.NoError(t, err)
+	defer sqlRows.Close()
+
+	// Get column names
+	columns, err = sqlRows.Columns()
+	require.NoError(t, err)
+
+	// Get column types
+	sqlColumnTypes, err := sqlRows.ColumnTypes()
+	require.NoError(t, err)
+	columnTypes = make([]string, len(sqlColumnTypes))
+	for i, ct := range sqlColumnTypes {
+		columnTypes[i] = ct.DatabaseTypeName()
+	}
+
+	// Collect rows
+	rows = make([][]interface{}, 0)
+	for sqlRows.Next() {
+		row := make([]interface{}, len(columns))
+		dest := make([]interface{}, len(columns))
+		for i := range dest {
+			dest[i] = &row[i]
+		}
+		err := sqlRows.Scan(dest...)
+		require.NoError(t, err)
+		rows = append(rows, row)
+	}
+	require.NoError(t, sqlRows.Err())
+
+	return columns, columnTypes, rows
+}
+
+// Execute a polling query until completion and return all results
+func executePolling(
+	t *testing.T,
+	dsn string,
+	query string,
+	args ...interface{},
+) (columns []string, columnTypes []string, rows [][]interface{}) {
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := pollingConn.StartQuery(ctx, query, args...)
+	require.NoError(t, err)
+
+	allRows, cols, colTypes, err := collectAllResults(ctx, pollingConn, result)
+	require.NoError(t, err)
+
+	// Convert column types to string names
+	columnTypes = make([]string, len(colTypes))
+	for i, ct := range colTypes {
+		columnTypes[i] = ct.DatabaseTypeName()
+	}
+
+	return cols, columnTypes, allRows
 }

--- a/trino/polling_integration_test.go
+++ b/trino/polling_integration_test.go
@@ -1,0 +1,254 @@
+package trino
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Polling client integration tests
+
+func TestIntegrationPollingSelectQueryNoResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := pollingConn.StartQuery(ctx, "SELECT * FROM system.runtime.nodes WHERE false")
+	require.NoError(t, err)
+
+	rows, _, _, err := collectAllResults(ctx, pollingConn, result)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestIntegrationPollingSelectFailedQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := pollingConn.StartQuery(ctx, "SELECT * FROM catalog.schema.do_not_exist")
+
+	// Poll until we get an error or query finishes
+	for err == nil && result != nil && !result.Finished {
+		result, err = pollingConn.PollQuery(ctx, result.NextURI)
+	}
+
+	require.Error(t, err, "Query to invalid catalog should fail")
+
+	queryFailed, ok := err.(*ErrQueryFailed)
+	require.True(t, ok, "Expected ErrQueryFailed, got: %T", err)
+
+	trinoErr, ok := errors.Unwrap(queryFailed).(*ErrTrino)
+	require.True(t, ok, "Expected ErrTrino, got: %T", errors.Unwrap(queryFailed))
+	assert.Equal(t, "CATALOG_NOT_FOUND", trinoErr.ErrorName)
+}
+
+func TestIntegrationPollingSelectTpch1000(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := pollingConn.StartQuery(ctx, "SELECT * FROM tpch.sf1.customer LIMIT 1000")
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.QueryID)
+
+	rows, columns, columnTypes, err := collectAllResults(ctx, pollingConn, result)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1000)
+	assert.Len(t, columnTypes, 8)
+
+	expectedColumns := []string{"custkey", "name", "address", "nationkey", "phone", "acctbal", "mktsegment", "comment"}
+	assert.Equal(t, expectedColumns, columns)
+
+	expectedColumnTypes := []*PollingColumnType{
+		{name: "custkey", databaseType: "BIGINT"},
+		{name: "name", databaseType: "VARCHAR", hasLength: true, length: 25},
+		{name: "address", databaseType: "VARCHAR", hasLength: true, length: 40},
+		{name: "nationkey", databaseType: "BIGINT"},
+		{name: "phone", databaseType: "VARCHAR", hasLength: true, length: 15},
+		{name: "acctbal", databaseType: "DOUBLE"},
+		{name: "mktsegment", databaseType: "VARCHAR", hasLength: true, length: 10},
+		{name: "comment", databaseType: "VARCHAR", hasLength: true, length: 117},
+	}
+
+	// compare everything but the scanType, which is a pointer to a reflect.Type
+	for i := range expectedColumnTypes {
+		actualType := columnTypes[i]
+		actualType.scanType = nil
+		assert.Equal(t, expectedColumnTypes[i], actualType)
+	}
+}
+
+func TestIntegrationPollingQueryWithNoResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{"USE statement", "USE tpch.sf1"},
+		{"SELECT with false condition", "SELECT 1 WHERE false"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := pollingConn.StartQuery(ctx, tc.query)
+			require.NoError(t, err)
+
+			rows, _, _, err := collectAllResults(ctx, pollingConn, result)
+			require.NoError(t, err)
+			assert.Empty(t, rows, "Expected no data rows for query: %s", tc.query)
+		})
+	}
+}
+
+func TestIntegrationPollingQueryWithParameters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name     string
+		query    string
+		param    interface{}
+		expected [][]interface{}
+	}{
+		{
+			name:     "system table filter",
+			query:    "SELECT node_id FROM system.runtime.nodes WHERE node_id = ?",
+			param:    "test",
+			expected: [][]interface{}{{"test"}},
+		},
+		{
+			name:     "sequence with numeric parameter",
+			query:    "SELECT * FROM TABLE(sequence(1, 10)) AS t(n) WHERE n = ?",
+			param:    2,
+			expected: [][]interface{}{{int64(2)}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := pollingConn.StartQuery(
+				ctx,
+				tc.query,
+				tc.param,
+			)
+			require.NoError(t, err)
+
+			rows, _, _, err := collectAllResults(ctx, pollingConn, result)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, rows)
+		})
+	}
+}
+
+func TestIntegrationPollingQueryWithNamedArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+
+	dsn := *integrationServerFlag
+	pollingConn, err := NewPollingConn(dsn, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test using sql.Named for X-Trino headers
+	result, err := pollingConn.StartQuery(
+		ctx,
+		"SELECT 1",
+		sql.Named("X-Trino-User", "test-user"),
+		sql.Named("X-Trino-Source", "test-source"),
+	)
+	require.NoError(t, err)
+
+	rows, _, _, err := collectAllResults(ctx, pollingConn, result)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, [][]interface{}{{int64(1)}}, rows)
+}
+
+// collectAllResults is a helper that polls until the query finishes and collects all results.
+func collectAllResults(ctx context.Context, pc *PollingConn, result *PollingResult) ([][]interface{}, []string, []*PollingColumnType, error) {
+	var err error
+	var allRows [][]interface{}
+	var columns []string
+	var columnTypes []*PollingColumnType
+
+	for !result.Finished {
+		if result.Rows != nil {
+			// Capture metadata from first result with rows
+			if len(columns) == 0 {
+				columns, _ = result.Rows.Columns()
+				columnTypes, _ = result.Rows.ColumnTypes()
+			}
+
+			rows, err := scanAllRows(result.Rows)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			allRows = append(allRows, rows...)
+		}
+
+		result, err = pc.PollQuery(ctx, result.NextURI)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	return allRows, columns, columnTypes, nil
+}
+
+// scanAllRows scans all rows from a PollingRows into [][]interface{}
+func scanAllRows(pr *PollingRows) ([][]interface{}, error) {
+	cols, _ := pr.Columns()
+	var rows [][]interface{}
+
+	for pr.Next() {
+		row := make([]interface{}, len(cols))
+		dest := make([]interface{}, len(cols))
+		for i := range dest {
+			dest[i] = &row[i]
+		}
+		if err := pr.Scan(dest...); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+
+	return rows, pr.Err()
+}

--- a/trino/polling_test.go
+++ b/trino/polling_test.go
@@ -1,0 +1,128 @@
+package trino
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertQueryArgsToDriverArgs(t *testing.T) {
+	t.Run("converts named args and positional args", func(t *testing.T) {
+		result := convertQueryArgsToDriverArgs(
+			sql.Named("X-Trino-User", "my-user"),
+			sql.Named("X-Trino-Source", "my-source"),
+			1,
+			"a",
+		)
+
+		expected := []driver.NamedValue{
+			{Name: "X-Trino-User", Ordinal: 1, Value: "my-user"},
+			{Name: "X-Trino-Source", Ordinal: 2, Value: "my-source"},
+			{Name: "", Ordinal: 3, Value: 1},
+			{Name: "", Ordinal: 4, Value: "a"},
+		}
+
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("handles driver.NamedValue directly", func(t *testing.T) {
+		result := convertQueryArgsToDriverArgs(
+			driver.NamedValue{Name: "test", Value: "value"},
+			&driver.NamedValue{Name: "test2", Value: "value2"},
+		)
+
+		assert.Equal(t, "test", result[0].Name)
+		assert.Equal(t, "value", result[0].Value)
+		assert.Equal(t, 1, result[0].Ordinal)
+
+		assert.Equal(t, "test2", result[1].Name)
+		assert.Equal(t, "value2", result[1].Value)
+		assert.Equal(t, 2, result[1].Ordinal)
+	})
+
+	t.Run("handles nil pointer", func(t *testing.T) {
+		var nilNamedArg *sql.NamedArg
+		result := convertQueryArgsToDriverArgs(nilNamedArg)
+
+		assert.Equal(t, 1, result[0].Ordinal)
+		assert.Nil(t, result[0].Value)
+	})
+}
+
+func TestPollingRows(t *testing.T) {
+	t.Run("Next and Scan iterate through rows", func(t *testing.T) {
+		pr := newPollingRows(
+			[]string{"id", "name"},
+			[]*PollingColumnType{
+				{name: "id", databaseType: "INTEGER"},
+				{name: "name", databaseType: "VARCHAR"},
+			},
+			[][]interface{}{
+				{int64(1), "Alice"},
+				{int64(2), "Bob"},
+				{int64(3), "Charlie"},
+			},
+		)
+
+		// Read first row
+		require.True(t, pr.Next())
+		var id int64
+		var name string
+		err := pr.Scan(&id, &name)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), id)
+		assert.Equal(t, "Alice", name)
+
+		// Read second row
+		require.True(t, pr.Next())
+		err = pr.Scan(&id, &name)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), id)
+		assert.Equal(t, "Bob", name)
+
+		// Read third row
+		require.True(t, pr.Next())
+		err = pr.Scan(&id, &name)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), id)
+		assert.Equal(t, "Charlie", name)
+
+		// No more rows
+		require.False(t, pr.Next())
+	})
+
+	t.Run("Scan returns error for mismatched column count", func(t *testing.T) {
+		pr := newPollingRows(
+			[]string{"id", "name"},
+			[]*PollingColumnType{
+				{name: "id", databaseType: "INTEGER"},
+				{name: "name", databaseType: "VARCHAR"},
+			},
+			[][]interface{}{
+				{int64(1), "Alice"},
+			},
+		)
+
+		require.True(t, pr.Next())
+
+		var id int64
+		err := pr.Scan(&id) // Only one destination, but two columns
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 2 destination arguments")
+	})
+
+	t.Run("Columns returns column names", func(t *testing.T) {
+		pr := newPollingRows(
+			[]string{"id", "name", "age"},
+			[]*PollingColumnType{},
+			[][]interface{}{},
+		)
+
+		columns, err := pr.Columns()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"id", "name", "age"}, columns)
+	})
+}


### PR DESCRIPTION
Expose Trino's underlying polling API with an alternative polling client.

This client allows polling for partial results without blocking, by exposing a query's `nextUri` to the caller and using it to retrieve additional results until query completion.

This client allows callers to work with partial results using the same patterns they'd use with the Trino `database/sql` driver. This is done by returning an interface equivalent to `sql.Rows`, and doing a similar type conversion.

Example usage
---------------

```go
conn, err := trino.NewPollingConn("http://localhost:8080", nil)
if err != nil { return err }

result, err := conn.StartQuery(ctx, "SELECT * FROM tpch.sf1.customer LIMIT 100")
if err != nil { return err }

for !result.Finished {
    // Process any rows returned in this poll
    if result.Rows != nil {
        for result.Rows.Next() {
            var name, address string
            err := result.Rows.Scan(&name, &address)
            if err != nil { return err }
            // process the row ...
        }
    }

    // Poll for more results
    result, err = conn.PollQuery(ctx, result.NextURI)
    if err != nil { return err }
}
```
