### PR TITLE
Bring patches from v0.316.0-dd-patch into v0.333.0

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -2547,7 +2547,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		v = sql.NullFloat64{}
 	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
 		v = sql.NullTime{}
-	case "map", "hstore":
+	case "map", "hstore", "hstore_csv":
 		v = NullMap{}
 	case "array":
 		if len(typeNames) <= 1 {
@@ -2650,7 +2650,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Time, err
-	case "map", "hstore":
+	case "map", "hstore", "hstore_csv":
 		if err := validateMap(v); err != nil {
 			return nil, err
 		}

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -2533,7 +2533,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 	switch typeNames[0] {
 	case "boolean":
 		v = sql.NullBool{}
-	case "json", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
 		v = sql.NullString{}
 	case "varbinary":
 		v = []byte{}
@@ -2620,7 +2620,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
+	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -2547,7 +2547,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		v = sql.NullFloat64{}
 	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
 		v = sql.NullTime{}
-	case "map":
+	case "map", "hstore":
 		v = NullMap{}
 	case "array":
 		if len(typeNames) <= 1 {
@@ -2650,7 +2650,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Time, err
-	case "map":
+	case "map", "hstore":
 		if err := validateMap(v); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Move DD-specific patches from `v0.316.0-dd-patch` onto `v0.333.0-dd-patch`.

Same as done in https://github.com/DataDog/trino-go-client/pull/6.

Checks
-------

- The PR's changes match the patches in v0.316.0-dd-patch: https://github.com/DataDog/trino-go-client/compare/v0.316.0...v0.316.0-dd-patch
- Identified breaking changes to keep in mind (https://github.com/DataDog/trino-go-client/compare/v0.316.0...v0.333.0):
  - VARBINARY is now returned as `byte[]` instead of `string`: https://github.com/trinodb/trino-go-client/pull/135