### PR TITLE
Add pgcompatible_inet type support

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -2533,7 +2533,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 	switch typeNames[0] {
 	case "boolean":
 		v = sql.NullBool{}
-	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "pgcompatible_inet", "uuid", "unknown":
 		v = sql.NullString{}
 	case "varbinary":
 		v = []byte{}
@@ -2556,7 +2556,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		switch typeNames[1] {
 		case "boolean":
 			v = NullSliceBool{}
-		case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+		case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "pgcompatible_inet", "uuid", "unknown":
 			v = NullSliceString{}
 		case "tinyint", "smallint", "integer", "bigint":
 			v = NullSliceInt64{}
@@ -2573,7 +2573,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 			switch typeNames[2] {
 			case "boolean":
 				v = NullSlice2Bool{}
-			case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+			case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "pgcompatible_inet", "uuid", "unknown":
 				v = NullSlice2String{}
 			case "tinyint", "smallint", "integer", "bigint":
 				v = NullSlice2Int64{}
@@ -2590,7 +2590,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 				switch typeNames[3] {
 				case "boolean":
 					v = NullSlice3Bool{}
-				case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+				case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "pgcompatible_inet", "uuid", "unknown":
 					v = NullSlice3String{}
 				case "tinyint", "smallint", "integer", "bigint":
 					v = NullSlice3Int64{}
@@ -2620,7 +2620,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
+	case "json", "pgjson", "char", "varchar", "interval year to month", "interval day to second", "decimal", "ipaddress", "pgcompatible_inet", "uuid", "Geometry", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err


### PR DESCRIPTION
## Summary
- Add `pgcompatible_inet` to all string type cases in `getScanType` and `ConvertValue`
- Same treatment as `ipaddress`, `hstore`, and other custom string-like types
- Needed for Retriever to surface inet values from Trino queries (AQG-373)

Tested in staging:
```
dd_env=staging
base_url="retriever.us1.$dd_env.dog:443" 
sql_query="SELECT pgcompatible_inet '192.168.1.5/24'"
grpcurl -v -H "$(ddauth obo -o 2)" \
-H "authorization: Bearer $(ddtool auth token --datacenter us1.$dd_env.dog rapid-xpq)" \
-d "{
\"org_id\": 2, \"source\": { \"source\": \"manual_test\" },
\"sql\": \"$sql_query\",
\"execution_engine\": 1
}" \
"$base_url" retrieverpb.RetrieverService/ExecuteSql
```