### PR TITLE
XPQG-2293: Add pgcompatible_date type support

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -2545,7 +2545,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 		v = sql.NullInt64{}
 	case "real", "double":
 		v = sql.NullFloat64{}
-	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
+	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone", "pgcompatible_date":
 		v = sql.NullTime{}
 	case "map", "hstore", "hstore_csv":
 		v = NullMap{}
@@ -2562,7 +2562,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 			v = NullSliceInt64{}
 		case "real", "double":
 			v = NullSliceFloat64{}
-		case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
+		case "date", "time", "time with time zone", "timestamp", "timestamp with time zone", "pgcompatible_date":
 			v = NullSliceTime{}
 		case "map":
 			v = NullSliceMap{}
@@ -2579,7 +2579,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 				v = NullSlice2Int64{}
 			case "real", "double":
 				v = NullSlice2Float64{}
-			case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
+			case "date", "time", "time with time zone", "timestamp", "timestamp with time zone", "pgcompatible_date":
 				v = NullSlice2Time{}
 			case "map":
 				v = NullSlice2Map{}
@@ -2596,7 +2596,7 @@ func getScanType(typeNames []string) (reflect.Type, error) {
 					v = NullSlice3Int64{}
 				case "real", "double":
 					v = NullSlice3Float64{}
-				case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
+				case "date", "time", "time with time zone", "timestamp", "timestamp with time zone", "pgcompatible_date":
 					v = NullSlice3Time{}
 				case "map":
 					v = NullSlice3Map{}
@@ -2644,7 +2644,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Float64, err
-	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone":
+	case "date", "time", "time with time zone", "timestamp", "timestamp with time zone", "pgcompatible_date":
 		vv, err := scanNullTime(v)
 		if !vv.Valid {
 			return nil, err


### PR DESCRIPTION
## Summary
- Teach the Trino Go client to recognize `PGCOMPATIBLE_DATE` as a column type
- Decode it the same way as native `DATE` (`time.Time`), since the wire representation is identical
- Follows the same pattern as PR #13 (PGCOMPATIBLE_INET)

## Test plan
- [x] `go build` / `go vet` pass
- [x] Staging:
```fish
set dd_env staging; set base_url retriever.us1.$dd_env.dog:443
grpcurl -v -H "$(ddauth obo -o 2)" \
  -H "authorization: Bearer $(ddtool auth token --datacenter us1.$dd_env.dog rapid-xpq)" \
-d '{
  "org_id": 2, "source": { "source": "manual_test" },
  "sql": "SELECT PGCOMPATIBLE_DATE \'2024-03-22\'",
  "execution_engine": 1
}' \
$base_url retrieverpb.RetrieverService/ExecuteSql
```